### PR TITLE
Added instantiate() method

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Execute Tests
         run: composer ci-tests-with-coverage
       - name: Run Static Analysis
-        run: composer ci-stan
+        run: composer ci-static-analysis

--- a/README.md
+++ b/README.md
@@ -61,20 +61,21 @@ There is no support for Union or Intersection properties.
 
 ## Instantiation
 
-Static `instantiate(callable)` method may be used _in lieu_ of a `__construct()`. It accepts a callable bound to a new
-instance and invoked before executing default value unmarshallers on uninitialized `public` properties. It behaves like
-the constructor of a readonly object, i.e. once a property is initialized, it can no longer be changed.
-
 DTOs may be hydrated in different ways:
 
-- Using the exception safe constructor `__construct()`
+- Using the exception-safe constructor `__construct()`
 - Using the static `from()` method
 - Using the static `lazy()` method, which creates a lazy object whose initialization is deferred until its state is
   observed or modified
 
 Hydrating methods above accept anything that can be passed to `iterator_to_array()` _i.e._ `iterable` (including `array`,
 `ArrayObject` and `DataTransferObject` itself), `stdClass`, or any SPL data structure; freshly decoded JSON can
-immediately be passed to any of them to hydrate a DTO, with or without array associativity.
+immediately be passed to any of them to hydrate a DTO, with associative arrays or objects.
+
+To create new DTOs, static `instantiate(callable)` method may be used _in lieu_ of `__construct()`. It accepts a
+`callable` bound to a new instance and invoked before executing default value unmarshallers on uninitialized `public`
+properties. It behaves like the constructor of a `readonly` object, _i.e._ once a property is initialized, it can no
+longer be changed.
 
 ```php
 <?php

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ A DTO (Data Transfer Object) is a simple object holding data.
 - It MUST be easy to understand
 - It MUST present and allow data transport in the simplest way
 - It MUST not contain business logic
-- It SHOULD be immutable, _i.e._ immune to modifications
+- It SHOULD be immutable, _i.e._ its state should not change after it is created
 
 This is Phlux.
 
 ## Declaration
 
-A Phlux DTO is strictly declared using PHP language constructs.
+A Phlux DTO is strictly declared using PHP language constructs; there is no magic.
 
 One can extend the `readonly` class `Data` or implement `DataTransferObject`
 which in on itself is `JsonSerializable` and `IteratorAggregate`.
@@ -37,7 +37,7 @@ of the collection's item (non-`public` properties can used as prototype for that
 All properties can be nullable by prefixing the type name with a question mark.
 
 When the data for a property is missing from a payload, unless a `#[Present]` attribute
-is found on the property indicating to skip initialization, a default value is assigned:
+is found on the property (indicating to skip initialization), a default value is assigned:
 
 - `null` when nullable
 - `0` for `int`
@@ -50,6 +50,8 @@ is found on the property indicating to skip initialization, a default value is a
 - The first `BackedEnum::cases()` item for `enum`
 - A new instance with `null` payload for anything implementing `DataTransferObject`
 
+Uninitialized properties are not exported to JSON.
+
 Adding the `#[Discriminator]` attribute on a `DataTransferObject` class (MUST be `abstract`)
 allows for inheritance and polymorphism of DTOs and their properties to hydrate. It must be given the name of a
 `final`, non-nullable `string` property on the attributed class containing the discriminator value which can be matched
@@ -59,6 +61,10 @@ There is no support for Union or Intersection properties.
 
 ## Instantiation
 
+Static `instantiate(callable)` method may be used _in lieu_ of a `__construct()`. It accepts a callable bound to a new
+instance and invoked before executing default value unmarshallers on uninitialized `public` properties. It behaves like
+the constructor of a readonly object, i.e. once a property is initialized, it can no longer be changed.
+
 DTOs may be hydrated in different ways:
 
 - Using the exception safe constructor `__construct()`
@@ -66,9 +72,9 @@ DTOs may be hydrated in different ways:
 - Using the static `lazy()` method, which creates a lazy object whose initialization is deferred until its state is
   observed or modified
 
-All the methods above accept anything that can be passed to `iterator_to_array()`, _i.e._ `iterable` (including `array`,
+Hydrating methods above accept anything that can be passed to `iterator_to_array()` _i.e._ `iterable` (including `array`,
 `ArrayObject` and `DataTransferObject` itself), `stdClass`, or any SPL data structure; freshly decoded JSON can
-immediately be passed to any of them to hydrate a DTO.
+immediately be passed to any of them to hydrate a DTO, with or without array associativity.
 
 ```php
 <?php
@@ -79,15 +85,30 @@ readonly class Person extends Webgraphe\Phlux\Data
     public string $lastName;
 }
 
-$json = '{"firstName":"John","lastName":"Doe"}';
-// Passing JSON-decoded data (a stdClass instance)
-$johnDoe = new Person(json_decode($json));
-// Passing another DTO
+// in-lieu of the constructor, creating with instantiate()
+$johnDoe = Person::instantiate(
+    function () {
+        $this->firstName = 'John';
+        $this->lastName = 'Doe';
+    }
+);
+
+// Creating from an existing DTO
 $johnDoeClone = Person::from($johnDoe);
-// A lazy-object hydrated from an associative array
-$lazyJohnDoe = Person::lazy(json_decode($json, true));
-// Object initializes its properties ONLY when reading them 
-echo $lazyPerson->firstName; // prints "John"
-// Encoding back to JSON
+
+// Encoding to JSON
 $json = json_encode($johnDoe);
+
+// Creating from decoded JSON
+$johnDoeDeepClone = Person::from(json_decode($johnDoe));
+
+// Creating as lazy-object, hydrated from an associative array
+$lazyJohnDoe = Person::lazy(json_decode($json, true));
+
+var_dump(Webgraphe\Phlux\Data::isLazy($lazyJohnDoe)); // true
+
+// Object initializes its properties ONLY when reading them 
+echo $lazyJohnDoe->firstName; // prints "John"
+
+var_dump(Webgraphe\Phlux\Data::isLazy($lazyJohnDoe)); // false; it's now initialized
 ```

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "ci-tests-with-coverage": [
             "php -dxdebug.mode=coverage vendor/bin/phpunit --fail-on-all-issues --testsuite \"CI\" --coverage-text"
         ],
-        "ci-stan": [
+        "ci-static-analysis": [
             "vendor/bin/phpstan --configuration=phpstan.src.neon.dist --no-progress"
         ]
     },

--- a/src/Contracts/Initializer.php
+++ b/src/Contracts/Initializer.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webgraphe\Phlux\Contracts;
+
+interface Initializer
+{
+    public function __invoke(): void;
+}

--- a/src/Data.php
+++ b/src/Data.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Webgraphe\Phlux;
 
+use Closure;
+use ReflectionProperty;
 use stdClass;
 use Traversable;
 use Webgraphe\Phlux\Contracts\DataTransferObject;
+use Webgraphe\Phlux\Contracts\Initializer;
 use Webgraphe\Phlux\Exceptions\DiscriminatorException;
 use Webgraphe\Phlux\Exceptions\PresentException;
 
@@ -39,7 +42,7 @@ abstract readonly class Data implements DataTransferObject
          * @noinspection PhpIncompatibleReturnTypeInspection
          * @phpstan-ignore return.type
          */
-        return static::discriminatedMeta($data)->reflectionClass()->newLazyGhost(
+        return self::discriminatedMeta(static::meta(), $data)->reflectionClass()->newLazyGhost(
             function (self $instance) use ($data) {
                 Meta::lazy(static fn() => $instance->__construct($data));
             },
@@ -52,17 +55,17 @@ abstract readonly class Data implements DataTransferObject
     final public static function from(iterable|stdClass|null $data): static
     {
         // @phpstan-ignore return.type
-        return new (static::discriminatedMeta($data)->class)($data);
+        return new (self::discriminatedMeta(static::meta(), $data)->class)($data);
     }
 
     /**
      * @throws DiscriminatorException
      */
-    public static function discriminatedMeta(iterable|stdClass|null $data): Meta
+    private static function discriminatedMeta(Meta $meta, iterable|stdClass|null $data): Meta
     {
-        return ($discriminator = static::meta()->getDiscriminator())
-            ? Meta::get($discriminator->resolveClass($data, static::class))
-            : static::meta();
+        return ($discriminator = $meta->getDiscriminator())
+            ? Meta::get($discriminator->resolveClass($data, $meta->class))
+            : $meta;
     }
 
     public static function meta(): Meta
@@ -84,5 +87,28 @@ abstract readonly class Data implements DataTransferObject
     {
         // Using Meta to return public vars only
         yield from static::meta()->vars($this);
+    }
+
+    /**
+     * @param Initializer|callable(): void $initializer
+     * @return static
+     */
+    public static function instantiate(Initializer|callable $initializer): static
+    {
+        $reflection = static::meta()->reflectionClass();
+        /** @var static $instance */
+        $instance = (static fn() => $reflection->newInstanceWithoutConstructor())();
+        $initializer(...)->call($instance);
+        $properties = static::meta()->reflectionProperties();
+        foreach (static::meta()->unmarshallers() as $name => $unmarshaller) {
+            if (!$properties[$name]->isInitialized($instance)) {
+                try {
+                    $instance->$name = $unmarshaller();
+                } catch (PresentException) {
+                }
+            }
+        }
+
+        return $instance;
     }
 }

--- a/src/Data.php
+++ b/src/Data.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Webgraphe\Phlux;
 
-use Closure;
-use ReflectionProperty;
 use stdClass;
 use Traversable;
 use Webgraphe\Phlux\Contracts\DataTransferObject;
@@ -47,6 +45,11 @@ abstract readonly class Data implements DataTransferObject
                 Meta::lazy(static fn() => $instance->__construct($data));
             },
         );
+    }
+
+    final public static function isLazy(self $instance): bool
+    {
+        return Meta::get($instance::class)->reflectionClass()->isUninitializedLazyObject($instance);
     }
 
     /**

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -101,19 +101,32 @@ final class Meta implements EventEmitter
     }
 
     /**
+     * @return array<string, ReflectionProperty>
+     */
+    public function reflectionProperties(): array
+    {
+        return array_combine(
+            array_map(
+                static fn(ReflectionProperty $property): string => $property->getName(),
+                $properties = self::reflectionClass()->getProperties(ReflectionProperty::IS_PUBLIC)
+            ),
+            $properties
+        );
+    }
+
+    /**
      * @throws DiscriminatorException
      */
     public function getDiscriminator(): ?Discriminator
     {
         if (!array_key_exists($this->class, self::$discriminators)) {
             $discriminated = $this->reflectionClass()->getAttributes(Discriminator::class)[0] ?? null;
-            if (self::$discriminators[$this->class] = $discriminator = $discriminated?->newInstance()) {
-                /** @var Discriminator|null $discriminator */
-                $property = (fn() => $this->reflectionClass()->getProperty($discriminator->propertyName))();
+            if ($discriminator = $discriminated?->newInstance()) {
                 if (!$this->reflectionClass()->isAbstract()) {
                     throw new DiscriminatorException("Discriminator MUST be declared on abstract class");
                 }
 
+                $property = (fn() => $this->reflectionClass()->getProperty($discriminator->propertyName))();
                 if ($property->getDeclaringClass()->getName() !== $this->class) {
                     throw new DiscriminatorException("Discriminator property MUST be declared on attributed class");
                 }
@@ -125,8 +138,13 @@ final class Meta implements EventEmitter
                 ) {
                     throw new DiscriminatorException("Discriminator property MUST be a final non-nullable string");
                 }
+
+                /** @var Discriminator|null $discriminator */
+                self::$discriminators[$this->class] = $discriminator;
             } elseif ($parent = array_values(class_parents($this->class))[0] ?? null) {
                 self::$discriminators[$this->class] = self::get($parent)->getDiscriminator();
+            } else {
+                self::$discriminators[$this->class] = null;
             }
         }
 

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -286,7 +286,7 @@ final class Meta implements EventEmitter
         $allowsNull = $type->allowsNull();
         $name = $type->getName();
 
-        return function (mixed $value) use ($allowsNull, $name): mixed {
+        return static function (mixed $value) use ($allowsNull, $name): mixed {
             if ($allowsNull && null === $value) {
                 return null;
             }
@@ -332,7 +332,7 @@ final class Meta implements EventEmitter
         $allowsNull = $type->allowsNull();
         $name = $type->getName();
 
-        return function (mixed $value) use ($allowsNull, $itemUnmarshaller, $name) {
+        return static function (mixed $value) use ($allowsNull, $itemUnmarshaller, $name) {
             if ($allowsNull && null === $value) {
                 return null;
             }

--- a/tests/Unit/DataTest.php
+++ b/tests/Unit/DataTest.php
@@ -162,14 +162,13 @@ class DataTest extends UnitTestCase
     public function testLazy(): void
     {
         $dto = Dummies\TestData::lazy(['data' => ['int' => 42]]);
-        $reflection = Dummies\TestData::meta()->reflectionClass();
-        self::assertTrue($reflection->isUninitializedLazyObject($dto));
+        self::assertTrue(Data::isLazy($dto));
         $data = $dto->data;
-        self::assertFalse($reflection->isUninitializedLazyObject($dto));
+        self::assertFalse(Data::isLazy($dto));
 
-        self::assertTrue($reflection->isUninitializedLazyObject($data));
+        self::assertTrue(Data::isLazy($data));
         self::assertEquals(42, $data->int);
-        self::assertFalse($reflection->isUninitializedLazyObject($data));
+        self::assertFalse(Data::isLazy($data));
     }
 
     public function testUnion(): void

--- a/tests/Unit/DataTest.php
+++ b/tests/Unit/DataTest.php
@@ -372,6 +372,7 @@ class DataTest extends UnitTestCase
         $this->expectExceptionObject(new DiscriminatorException('Discriminator property MUST be declared on attributed class'));
         AbstractAbstractMappedData::from(null);
     }
+
     public static function dataProviderInvalidDiscriminatorProperty(): array
     {
         return [
@@ -382,5 +383,18 @@ class DataTest extends UnitTestCase
                 'class' => Dummies\NonStringDiscriminatedData::class,
             ],
         ];
+    }
+
+    public function testInstantiate(): Dummies\TestData
+    {
+        $instance = Dummies\TestData::instantiate(
+            function (): void {
+                /** @noinspection PhpDynamicFieldDeclarationInspection */
+                $this->name = 'instantiated';
+            }
+        );
+        self::assertEquals('instantiated', $instance->name);
+
+        return $instance;
     }
 }


### PR DESCRIPTION
`Data::instantiate()` accepts a `callable` that's bound to a new instance (`$this`) and allows property assignment before executing default value unmarshallers on uninitialized `public` properties.