### PR TITLE
Removed Data::__construct(); added instantiate()

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.4]
+        php: [8.4, 8.5]
     name: PHP ${{ matrix.php }}
     steps:
       - name: Checkout Code

--- a/src/Contracts/DataTransferObject.php
+++ b/src/Contracts/DataTransferObject.php
@@ -11,7 +11,7 @@ use stdClass;
 
 interface DataTransferObject extends ArrayAccess, JsonSerializable, IteratorAggregate
 {
-    public function __construct(iterable|stdClass|null $data = null);
+    public static function instantiate(mixed ...$arguments): static;
 
     public static function lazy(iterable|stdClass|null $data): static;
 

--- a/src/Data.php
+++ b/src/Data.php
@@ -17,20 +17,16 @@ use Webgraphe\Phlux\Exceptions\PresentException;
  */
 abstract readonly class Data implements DataTransferObject
 {
-    private static function hydrate(self $instance, iterable|stdClass|null $data = null): static
+    final public static function instantiate(mixed ...$arguments): static
     {
-        $array = $data instanceof stdClass ? get_object_vars($data) : iterator_to_array($data ?? []);
+        $reflection = static::meta()->reflectionClass();
+        /**
+         * @var static $instance
+         * @noinspection PhpUnhandledExceptionInspection
+         */
+        $instance = $reflection->newInstanceWithoutConstructor();
 
-        foreach (static::meta()->unmarshallers() as $name => $unmarshaller) {
-            try {
-                $instance->$name = array_key_exists($name, $array)
-                    ? $unmarshaller($array[$name])
-                    : $unmarshaller();
-            } catch (PresentException) {
-            }
-        }
-
-        return $instance;
+        return $instance->hydrate($arguments);
     }
 
     /**
@@ -43,8 +39,8 @@ abstract readonly class Data implements DataTransferObject
          * @phpstan-ignore return.type
          */
         return self::discriminatedMeta(static::meta(), $data)->reflectionClass()->newLazyGhost(
-            function (self $instance) use ($data) {
-                Meta::lazy(static fn(): static => static::hydrate($instance, $data));
+            function (self $instance) use ($data): void {
+                Meta::lazy($instance->hydrate(...), $data);
             },
         );
     }
@@ -61,9 +57,25 @@ abstract readonly class Data implements DataTransferObject
     {
         $array = $data instanceof stdClass ? get_object_vars($data) : iterator_to_array($data ?? []);
 
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
         // @phpstan-ignore return.type
-        /** @noinspection PhpIncompatibleReturnTypeInspection Not returning a class-string<DataTransferObject> */
-        return self::discriminatedMeta(static::meta(), $data)->class::instantiate(...$array);
+        return (self::discriminatedMeta(static::meta(), $data)->class)::instantiate(...$array);
+    }
+
+    private function hydrate(iterable|stdClass|null $data = null): static
+    {
+        $array = $data instanceof stdClass ? get_object_vars($data) : iterator_to_array($data ?? []);
+
+        foreach (static::meta()->unmarshallers() as $name => $unmarshaller) {
+            try {
+                $this->$name = array_key_exists($name, $array)
+                    ? $unmarshaller($array[$name])
+                    : $unmarshaller();
+            } catch (PresentException) {
+            }
+        }
+
+        return $this;
     }
 
     /**
@@ -95,18 +107,6 @@ abstract readonly class Data implements DataTransferObject
     {
         // Using Meta to return public vars only
         yield from static::meta()->vars($this);
-    }
-
-    final public static function instantiate(mixed ...$arguments): static
-    {
-        $reflection = static::meta()->reflectionClass();
-        /**
-         * @var static $instance
-         * @noinspection PhpUnhandledExceptionInspection
-         */
-        $instance = $reflection->newInstanceWithoutConstructor();
-
-        return static::hydrate($instance, $arguments);
     }
 
     final public function offsetExists(mixed $offset): bool

--- a/src/Data.php
+++ b/src/Data.php
@@ -7,7 +7,6 @@ namespace Webgraphe\Phlux;
 use stdClass;
 use Traversable;
 use Webgraphe\Phlux\Contracts\DataTransferObject;
-use Webgraphe\Phlux\Contracts\Initializer;
 use Webgraphe\Phlux\Exceptions\DiscriminatorException;
 use Webgraphe\Phlux\Exceptions\PresentException;
 
@@ -18,17 +17,20 @@ use Webgraphe\Phlux\Exceptions\PresentException;
  */
 abstract readonly class Data implements DataTransferObject
 {
-    final public function __construct(iterable|stdClass|null $data = null)
+    private static function hydrate(self $instance, iterable|stdClass|null $data = null): static
     {
         $array = $data instanceof stdClass ? get_object_vars($data) : iterator_to_array($data ?? []);
+
         foreach (static::meta()->unmarshallers() as $name => $unmarshaller) {
             try {
-                $this->$name = array_key_exists($name, $array)
+                $instance->$name = array_key_exists($name, $array)
                     ? $unmarshaller($array[$name])
                     : $unmarshaller();
             } catch (PresentException) {
             }
         }
+
+        return $instance;
     }
 
     /**
@@ -42,7 +44,7 @@ abstract readonly class Data implements DataTransferObject
          */
         return self::discriminatedMeta(static::meta(), $data)->reflectionClass()->newLazyGhost(
             function (self $instance) use ($data) {
-                Meta::lazy(static fn() => $instance->__construct($data));
+                Meta::lazy(static fn(): static => static::hydrate($instance, $data));
             },
         );
     }
@@ -57,8 +59,11 @@ abstract readonly class Data implements DataTransferObject
      */
     final public static function from(iterable|stdClass|null $data): static
     {
+        $array = $data instanceof stdClass ? get_object_vars($data) : iterator_to_array($data ?? []);
+
         // @phpstan-ignore return.type
-        return new (self::discriminatedMeta(static::meta(), $data)->class)($data);
+        /** @noinspection PhpIncompatibleReturnTypeInspection Not returning a class-string<DataTransferObject> */
+        return self::discriminatedMeta(static::meta(), $data)->class::instantiate(...$array);
     }
 
     /**
@@ -92,27 +97,16 @@ abstract readonly class Data implements DataTransferObject
         yield from static::meta()->vars($this);
     }
 
-    /**
-     * @param Initializer|callable(): void $initializer
-     * @return static
-     */
-    final public static function instantiate(Initializer|callable $initializer): static
+    final public static function instantiate(mixed ...$arguments): static
     {
         $reflection = static::meta()->reflectionClass();
-        /** @var static $instance */
-        $instance = (static fn() => $reflection->newInstanceWithoutConstructor())();
-        $initializer(...)->call($instance);
-        $properties = static::meta()->reflectionProperties();
-        foreach (static::meta()->unmarshallers() as $name => $unmarshaller) {
-            if (!$properties[$name]->isInitialized($instance)) {
-                try {
-                    $instance->$name = $unmarshaller();
-                } catch (PresentException) {
-                }
-            }
-        }
+        /**
+         * @var static $instance
+         * @noinspection PhpUnhandledExceptionInspection
+         */
+        $instance = $reflection->newInstanceWithoutConstructor();
 
-        return $instance;
+        return static::hydrate($instance, $arguments);
     }
 
     final public function offsetExists(mixed $offset): bool

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -102,6 +102,7 @@ final class Meta implements EventEmitter
     public function reflectionClass(): ReflectionClass
     {
         return self::$reflections[$this->class]
+            // @phpstan-ignore return.type
             ??= (static fn(string $c): ReflectionClass => new ReflectionClass($c))($this->class);
     }
 

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -46,6 +46,9 @@ final class Meta implements EventEmitter
     /** @var array<string, Closure> Associated by property name */
     private array $unmarshallers = [];
 
+    /**
+     * @param class-string<DataTransferObject> $class
+     */
     private function __construct(public readonly string $class) {}
 
     public static function lazy(callable $callable, mixed ...$args): mixed
@@ -98,21 +101,8 @@ final class Meta implements EventEmitter
 
     public function reflectionClass(): ReflectionClass
     {
-        return self::$reflections[$this->class] ??= (static fn(string $c) => new ReflectionClass($c))($this->class);
-    }
-
-    /**
-     * @return array<string, ReflectionProperty>
-     */
-    public function reflectionProperties(): array
-    {
-        return array_combine(
-            array_map(
-                static fn(ReflectionProperty $property): string => $property->getName(),
-                $properties = self::reflectionClass()->getProperties(ReflectionProperty::IS_PUBLIC)
-            ),
-            $properties
-        );
+        return self::$reflections[$this->class]
+            ??= (static fn(string $c): ReflectionClass => new ReflectionClass($c))($this->class);
     }
 
     /**
@@ -277,7 +267,10 @@ final class Meta implements EventEmitter
 
         $allowsNull = $type->allowsNull();
 
-        return function (mixed $value) use ($allowsNull, $callable): mixed {
+        return function (mixed $value) use (
+            $allowsNull,
+            $callable,
+        ): DataTransferObject|DateTimeImmutable|BackedEnum|null {
             return (null === $value) && $allowsNull ? null : $callable($value);
         };
     }

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -102,7 +102,6 @@ final class Meta implements EventEmitter
     public function reflectionClass(): ReflectionClass
     {
         return self::$reflections[$this->class]
-            // @phpstan-ignore return.type
             ??= (static fn(string $c): ReflectionClass => new ReflectionClass($c))($this->class);
     }
 

--- a/tests/Dummies/IdentityData.php
+++ b/tests/Dummies/IdentityData.php
@@ -9,6 +9,7 @@ use Webgraphe\Phlux\Data;
 
 readonly class IdentityData extends Data
 {
-    #[Present]
-    public string $name;
+    public function __construct(
+        #[Present] public string $name,
+    ) {}
 }

--- a/tests/Unit/DataTest.php
+++ b/tests/Unit/DataTest.php
@@ -56,8 +56,11 @@ class DataTest extends UnitTestCase
 
     public function testIdentity(): void
     {
-        $dto = new Dummies\IdentityData();
+        $dto = new Dummies\IdentityData('');
+        self::assertEquals(['name' => ''], $dto->toArray());
+        $dto = Dummies\IdentityData::instantiate();
         self::assertEquals([], $dto->toArray());
+        self::assertFalse(isset($dto->name));
     }
 
     /**
@@ -65,8 +68,8 @@ class DataTest extends UnitTestCase
      */
     public function testScalars(): Dummies\TestData
     {
-        $dto = new Dummies\TestData(
-            $innerDto = new Dummies\TestData(
+        $dto = Dummies\TestData::from(
+            $innerDto = Dummies\TestData::from(
                 json_decode(
                     json_encode(
                         $data = [
@@ -138,8 +141,8 @@ class DataTest extends UnitTestCase
      */
     public function testComposites(): void
     {
-        $dto = new Dummies\TestData(
-            $innerDto = new Dummies\TestData(
+        $dto = Dummies\TestData::from(
+            $innerDto = Dummies\TestData::from(
                 json_decode(
                     json_encode(
                         $data = [
@@ -164,7 +167,7 @@ class DataTest extends UnitTestCase
         self::assertEquals(['foo', 'bar'], $dto->strings);
         self::assertEquals((object)['hello' => 'world'], $dto->nullableStringMap);
         self::assertEquals([['a', 'b'], ['c', 'd']], $dto->stringsArray);
-        self::assertEquals(new Dummies\TestData(['int' => 42]), $dto->data);
+        self::assertEquals(Dummies\TestData::from(['int' => 42]), $dto->data);
         self::assertEquals(
             $expected = [
                 ...$data,
@@ -193,8 +196,8 @@ class DataTest extends UnitTestCase
      */
     public function testJson(): void
     {
-        $json = json_encode($dto = new Dummies\TestData(null));
-        $fromJson = new Dummies\TestData(json_decode($json));
+        $json = json_encode($dto = Dummies\TestData::from(null));
+        $fromJson = Dummies\TestData::from(json_decode($json));
         self::assertEquals($dto->toArray(), $fromJson->toArray());
     }
 
@@ -217,7 +220,7 @@ class DataTest extends UnitTestCase
     {
         $this->expectExceptionObject(new UnsupportedPropertyTypeException('number'));
 
-        new Dummies\UnionData();
+        Dummies\UnionData::instantiate();
     }
 
     public function testUndefinedClass(): void
@@ -225,7 +228,7 @@ class DataTest extends UnitTestCase
         /** @noinspection PhpUndefinedClassInspection */
         $this->expectExceptionObject(new UnknownClassException(Dummies\Unknown::class));
 
-        new Dummies\UnknownClassData();
+        Dummies\UnknownClassData::instantiate();
     }
 
     public function testUnsupportedClass(): void
@@ -233,7 +236,7 @@ class DataTest extends UnitTestCase
         /** @noinspection PhpUndefinedClassInspection */
         $this->expectExceptionObject(new UnsupportedClassException(DateTime::class));
 
-        new Dummies\UnsupportedClassData();
+        Dummies\UnsupportedClassData::instantiate();
     }
 
     public function testUnsupportedComposite(): void
@@ -241,7 +244,7 @@ class DataTest extends UnitTestCase
         /** @noinspection PhpUndefinedClassInspection */
         $this->expectExceptionObject(new UnsupportedClassException(DateTime::class));
 
-        new Dummies\UnsupportedCompositeData();
+        Dummies\UnsupportedCompositeData::instantiate();
     }
 
     /**
@@ -326,9 +329,7 @@ class DataTest extends UnitTestCase
         /** @noinspection PhpUndefinedClassInspection */
         $class = Dummies\Discriminated\Undefined::class;
         $discriminator = Dummies\Discriminated\AbstractMappedData::undefined;
-        $this->expectExceptionObject(
-            new UndefinedClassDiscriminatorException($class),
-        );
+        $this->expectExceptionObject(new UndefinedClassDiscriminatorException($class));
         Dummies\Discriminated\AbstractMappedData::from(['type' => $discriminator]);
     }
 
@@ -352,9 +353,7 @@ class DataTest extends UnitTestCase
         /** @noinspection PhpUndefinedClassInspection */
         $class = Dummies\Discriminated\Undefined::class;
         $discriminator = 'Undefined';
-        $this->expectExceptionObject(
-            new UndefinedClassDiscriminatorException($class),
-        );
+        $this->expectExceptionObject(new UndefinedClassDiscriminatorException($class));
         Dummies\Discriminated\AbstractUnmappedData::from(['type' => $discriminator]);
     }
 
@@ -362,21 +361,19 @@ class DataTest extends UnitTestCase
     {
         /** @noinspection PhpUndefinedClassInspection */
         $class = Dummies\Discriminated\MappedUnmappedData::class;
-        $this->expectExceptionObject(
-            new UnmappedClassDiscriminatorException($class),
-        );
-        new Dummies\Discriminated\MappedUnmappedData();
+        $this->expectExceptionObject(new UnmappedClassDiscriminatorException($class));
+        Dummies\Discriminated\MappedUnmappedData::instantiate();
     }
 
     public function testNewMappedInstanceIsDiscriminated(): void
     {
-        $dto = new Dummies\Discriminated\MappedLeftData();
+        $dto = Dummies\Discriminated\MappedLeftData::instantiate();
         self::assertEquals(Dummies\Discriminated\AbstractMappedData::left, $dto->type);
     }
 
     public function testNewUnmappedInstanceIsDiscriminated(): void
     {
-        $dto = new Dummies\Discriminated\UnmappedRightData();
+        $dto = Dummies\Discriminated\UnmappedRightData::instantiate();
         self::assertEquals(Dummies\Discriminated\AbstractUnmappedData::UnmappedRightData, $dto->type);
     }
 
@@ -385,7 +382,7 @@ class DataTest extends UnitTestCase
         $this->expectExceptionObject(
             new InvalidNamespaceDiscriminatorException(Dummies\InvalidNamespaceUnmappedData::class)
         );
-        new Dummies\InvalidNamespaceUnmappedData();
+        Dummies\InvalidNamespaceUnmappedData::instantiate();
     }
 
     /**
@@ -428,12 +425,7 @@ class DataTest extends UnitTestCase
 
     public function testInstantiate(): Dummies\TestData
     {
-        $instance = Dummies\TestData::instantiate(
-            function (): void {
-                /** @noinspection PhpDynamicFieldDeclarationInspection */
-                $this->name = 'instantiated';
-            }
-        );
+        $instance = Dummies\TestData::instantiate(name: 'instantiated');
         self::assertEquals('instantiated', $instance->name);
 
         return $instance;
@@ -441,7 +433,7 @@ class DataTest extends UnitTestCase
 
     public function testBare(): void
     {
-        $bare = new Bare();
+        $bare = Bare::instantiate();
         self::assertJsonStringEqualsJsonString('{}', json_encode($bare));
     }
 }


### PR DESCRIPTION
- Instead of using the constructor passing an `iterable` (which includes associative `array`), `stdClass` or `null`, one should now resort to `from()` to use the same input, at the cost of possibly having to resolve a discriminated class.
- `instantiate()` now expects variable number of parameters named after the DTO `public` properties.
- These changes allow a DTO to declare its own `__construct` and perform property promotion while still supporting attributes and skipping the overhead cost of unmarshalling the input.
- Brings official support for PHP 8.5